### PR TITLE
Genrate random string by Yunohost command for .env

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -11,7 +11,7 @@ SITE_OWNER=yunomail
 # The encryption key for your database and sessions. Keep this very secure.
 # If you generate a new one all existing data must be considered LOST.
 # Change it to a string of exactly 32 chars or use command `php artisan key:generate` to generate it
-APP_KEY=SomeRandomStringOf32CharsExactly
+APP_KEY=random_key
 
 # Change this value to your preferred time zone.
 # Example: Europe/Amsterdam

--- a/scripts/install
+++ b/scripts/install
@@ -24,6 +24,7 @@ domain=$YNH_APP_ARG_DOMAIN
 path_url="/"
 admin=$YNH_APP_ARG_ADMIN
 is_public=$YNH_APP_ARG_IS_PUBLIC
+random_key=$(ynh_string_random 32)
 
 # This is a multi-instance app, meaning it can be installed several times independently
 # The id of the app as stated in the manifest is available as $YNH_APP_ID
@@ -60,6 +61,7 @@ ynh_app_setting_set $app domain $domain
 ynh_app_setting_set $app path $path_url
 ynh_app_setting_set $app admin $admin
 ynh_app_setting_set $app is_public $is_public
+ynh_app_setting_set $app random_key $random_key
 
 #=================================================
 # INSTALL DEPENDENCIES
@@ -85,8 +87,6 @@ ynh_app_setting_set $app final_path $final_path
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source "$final_path"
 
-
-
 #=================================================
 # NGINX CONFIGURATION
 #=================================================
@@ -108,7 +108,6 @@ ynh_system_user_create $app
 # Create a dedicated php-fpm7.1 config
 ynh_add_fpm7.1_config
 
-
 #=================================================
 # SPECIFIC SETUP
 #=================================================
@@ -121,15 +120,14 @@ sudo  cp ../conf/.env $final_path/.env
 #=================================================
 # MODIFY A CONFIG FILE
 #=================================================
-
-ynh_replace_string "yunouser"   "$db_name"  "$final_path/.env"
-ynh_replace_string "yunopass"   "$db_pwd"   "$final_path/.env"
-ynh_replace_string "yunobase"   "$db_name"  "$final_path/.env"
-ynh_replace_string "yunomail"   "$email"    "$final_path/.env"
-ynh_replace_string "yunodomain" "$domain"   "$final_path/.env"
+ynh_replace_string "random_key" "$random_key" "$final_path/.env"
+ynh_replace_string "yunouser"   "$db_name"    "$final_path/.env"
+ynh_replace_string "yunopass"   "$db_pwd"     "$final_path/.env"
+ynh_replace_string "yunobase"   "$db_name"    "$final_path/.env"
+ynh_replace_string "yunomail"   "$email"      "$final_path/.env"
+ynh_replace_string "yunodomain" "$domain"     "$final_path/.env"
 
 init_composer $final_path
-cd $final_path && sudo /usr/bin/php7.1 artisan -n key:generate --force
 cd $final_path && sudo /usr/bin/php7.1 artisan config:clear
 
 db_name=$(ynh_sanitize_dbid $app)
@@ -137,7 +135,6 @@ db_name=$(ynh_sanitize_dbid $app)
 # setup application config
 cd $final_path && sudo /usr/bin/php7.1 artisan -q :refresh --seed --force
 cd $final_path && sudo /usr/bin/php7.1 artisan passport:install  --force
-
 
 #=================================================
 # SETUP APPLICATION PERMISSIONS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -21,6 +21,7 @@ admin=$(ynh_app_setting_get $app admin)
 is_public=$(ynh_app_setting_get $app is_public)
 final_path=$(ynh_app_setting_get $app final_path)
 db_name=$(ynh_app_setting_get $app db_name)
+random_key=$(ynh_app_setting_get $app random_key)
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -40,8 +41,6 @@ if [ -z $db_name ]; then
 	db_name=$(ynh_sanitize_dbid $app)
 	ynh_app_setting_set $app db_name $db_name
 fi
-
-
 
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
@@ -76,7 +75,6 @@ mkdir -p "$tmpdir/storage/upload"
 mkdir -p "$tmpdir/storage/export"
 mkdir -p "$final_path/storage/upload/"
 mkdir -p "$final_path/storage/export/"
-cp -a "$final_path/.env" "$tmpdir/.env"
 cp -a "$final_path/storage/upload/" "$tmpdir/storage/upload/"
 cp -a "$final_path/storage/export/" "$tmpdir/storage/export/"
 
@@ -97,8 +95,7 @@ fi
 ynh_setup_source "$final_path"
 
 
-rm -rf "$final_path/bootstrap/cache/*"
-cp -a "$tmpdir/.env" "$final_path/.env" 
+rm -rf "$final_path/bootstrap/cache/*" 
 cp -a "$tmpdir/storage/upload/" "$final_path/storage/upload/" 
 cp -a "$tmpdir/storage/export/"  "$final_path/storage/export/" 
 
@@ -119,8 +116,6 @@ ynh_add_nginx_config
 # Create a system user
 ynh_system_user_create $app
 
-
-
 #=================================================
 # PHP-FPM 7.1 CONFIGURATION
 #=================================================
@@ -131,6 +126,22 @@ ynh_add_fpm7.1_config
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================
+# Get the admin email
+email=$(ynh_user_get_info $admin 'mail')
+
+# setup application config
+sudo  cp ../conf/.env $final_path/.env
+#=================================================
+# MODIFY A CONFIG FILE
+#=================================================
+ynh_replace_string "random_key" "$random_key" "$final_path/.env"
+ynh_replace_string "yunouser"   "$db_name"    "$final_path/.env"
+ynh_replace_string "yunopass"   "$db_pwd"     "$final_path/.env"
+ynh_replace_string "yunobase"   "$db_name"    "$final_path/.env"
+ynh_replace_string "yunomail"   "$email"      "$final_path/.env"
+ynh_replace_string "yunodomain" "$domain"     "$final_path/.env"
+
+
 init_composer $final_path
 cd $final_path && sudo /usr/bin/php7.1 artisan migrate --env=production --force
 cd $final_path && sudo /usr/bin/php7.1 artisan cache:clear


### PR DESCRIPTION
As .env file can have new entries in future, adding these changes from upgrade script is difficult. So better solution is to create a 32 character key by YunoHost and store it,so that .env can be copied by /conf/.env to the app folder every time upgrade script is run without changing the key in .env.  