### PR TITLE
Use `sendmail` to send mail.

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -117,7 +117,7 @@ COOKIE_SECURE=false
 # If you want Firefly III to mail you, update these settings
 # For instructions, see: https://docs.firefly-iii.org/advanced-installation/email
 # If you use Docker or similar, you can set these variables from a file by appending them with _FILE
-MAIL_MAILER=smtp
+MAIL_MAILER=sendmail
 MAIL_HOST=127.0.0.1
 MAIL_PORT=25
 MAIL_FROM=__EMAIL__


### PR DESCRIPTION
There seems to be a problem in interop between Laravel's mail system and default ynh conf that allows unauthenticated SMTP usage. Using `sendmail` gets around this problem.

## Problem
After installation of Firefly III and creating user app returns 500 on sending invitation.

## Solution
Use `sendmail` method gets around this problem.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
