### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 * Official app website: <https://firefly-iii.org/>
 * Official admin documentation: <https://docs.firefly-iii.org/firefly-iii/about-firefly-iii/introduction/>
 * Upstream app code repository: <https://github.com/firefly-iii/firefly-iii>
-* YunoHost documentation for this app: <https://yunohost.org/app_firefly-iii>
+* YunoHost Store: <https://apps.yunohost.org/app/firefly-iii>
 * Report a bug: <https://github.com/YunoHost-Apps/firefly-iii_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -32,7 +32,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 * Site officiel de l’app : <https://firefly-iii.org/>
 * Documentation officielle de l’admin : <https://docs.firefly-iii.org/firefly-iii/about-firefly-iii/introduction/>
 * Dépôt de code officiel de l’app : <https://github.com/firefly-iii/firefly-iii>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_firefly-iii>
+* YunoHost Store: <https://apps.yunohost.org/app/firefly-iii>
 * Signaler un bug : <https://github.com/YunoHost-Apps/firefly-iii_ynh/issues>
 
 ## Informations pour les développeurs

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,7 +54,7 @@ then
 	ynh_script_progression --message="Upgrading source files..."
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir" --keep=".env storage/upload storage/export"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep=".env storage/upload storage/export"
 fi
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```