### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -4,7 +4,7 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 email=$(ynh_user_get_info --username=$admin --key=mail)
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # MODIFY URL IN NGINX CONF

--- a/scripts/install
+++ b/scripts/install
@@ -5,7 +5,7 @@ source /usr/share/yunohost/helpers
 
 random_key=$(ynh_string_random --length=32)
 email=$(ynh_user_get_info --username=$admin --key=mail)
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 ynh_app_setting_set --key=random_key --value=$random_key
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -4,7 +4,7 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 email=$(ynh_user_get_info --username=$admin --key=mail)
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 ynh_app_setting_set_default --key=language --value="en_US"
 


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.